### PR TITLE
emit Problem::check error even if no url found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ impl Account {
         Ok(Order {
             account: self.inner.clone(),
             nonce,
-            url: order_url.ok_or("no order URL found")?,
             state: Problem::check::<OrderState>(rsp).await?,
+            url: order_url.ok_or("no order URL found")?,
         })
     }
 


### PR DESCRIPTION
Lets encrypt can return a clear error when creating a new order without returning an `order_url`. 

A missing `order_url` however triggers an early return with error message `no order URL found`. The error from lets encrypt is then never shown to the crate user.

Swapping the `state` and `url` field instantiation in `new_order`  is enough to let `Problem::check` emit the lets encrypt error.

### Example case
Requesting a certificate for *example.org*:
Original output:
```
missing data: no order URL found
```

New:
```
API error: Error creating new order :: Cannot issue for "example.org": The ACME server refuses to issue a certificate for this domain name, because it is forbidden by policy (urn:ietf:params:acme:error:rejectedIdentifier)
```