### PR TITLE
Add comment to prevent swapping fields causing wrong early return 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ impl Account {
         Ok(Order {
             account: self.inner.clone(),
             nonce,
-            // Order of fields matters! We return errors from Problem::check 
+            // Order of fields matters! We return errors from Problem::check
             // before emitting an error if there is no order url. Or the
             // simple no url error hides the causing error in `Problem::check`.
             state: Problem::check::<OrderState>(rsp).await?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,9 @@ impl Account {
         Ok(Order {
             account: self.inner.clone(),
             nonce,
+            // Order of fields matters! We return errors from Problem::check 
+            // before emitting an error if there is no order url. Or the
+            // simple no url error hides the causing error in `Problem::check`.
             state: Problem::check::<OrderState>(rsp).await?,
             url: order_url.ok_or("no order URL found")?,
         })


### PR DESCRIPTION
See PR #17 for the original issue

edit: worked on the wrong branch and then pressed PR so it took a rebase to get this to merge cleanly. Which is why the force-push is there