### PR TITLE
Re-Add Send,Sync to HttpClient with option to remove

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.60.0"
 
 [features]
 default = ["hyper-rustls"]
+single-thread = []
 
 [dependencies]
 base64 = "0.21.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,6 +621,12 @@ impl Default for DefaultClient {
 }
 
 /// A HTTP client based on [`hyper::Client`]
+#[cfg(all(feature = "hyper-rustls", not(feature = "single-thread")))]
+pub trait HttpClient: Send + Sync {
+    /// Send the given request and return the response
+    fn request(&self, req: Request<Body>) -> ResponseFuture;
+}
+#[cfg(all(feature = "hyper-rustls", feature = "single-thread"))]
 pub trait HttpClient {
     /// Send the given request and return the response
     fn request(&self, req: Request<Body>) -> ResponseFuture;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,6 +626,7 @@ pub trait HttpClient: Send + Sync {
     /// Send the given request and return the response
     fn request(&self, req: Request<Body>) -> ResponseFuture;
 }
+/// A HTTP client based on [`hyper::Client`]
 #[cfg(all(feature = "hyper-rustls", feature = "single-thread"))]
 pub trait HttpClient {
     /// Send the given request and return the response


### PR DESCRIPTION
Adresses https://github.com/instant-labs/instant-acme/issues/25 by adding Send and Sync bounds to the HttpClient trait. Adds feature "single-thread" that removes those bounds again.

Rust specifies features should be addative (enable) functionality instead of restricting it. As adding bounds would restrict trait implementation I chose to let the feature remove the bounds.

To maintain semver the minor version needs to be increased.