### PR TITLE
Add some bounds for HttpClient trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Async pure-Rust ACME client"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,7 +621,7 @@ impl Default for DefaultClient {
 }
 
 /// A HTTP client based on [`hyper::Client`]
-pub trait HttpClient {
+pub trait HttpClient: Send + Sync + 'static {
     /// Send the given request and return the response
     fn request(&self, req: Request<Body>) -> ResponseFuture;
 }


### PR DESCRIPTION
@surban @dvdsk I think I'd prefer to keep this simple -- it seems very unlikely to me that anyone started using instant-acme 0.3.1 with a non-`Send + Sync + 'static` client in the past 2 days. Does this work for your use cases?

Fixes #25. Alternative to #26.