### PR TITLE
Improve credential handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Async pure-Rust ACME client"

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -72,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
 
         let Identifier::Dns(identifier) = &authz.identifier;
 
-        println!("Please set the following DNS record then press any key:");
+        println!("Please set the following DNS record then press the Return key:");
         println!(
             "_acme-challenge.{} IN TXT {}",
             identifier,
@@ -106,7 +106,7 @@ async fn main() -> anyhow::Result<()> {
         match tries < 5 {
             true => info!(?state, tries, "order is not ready, waiting {delay:?}"),
             false => {
-                error!(?state, tries, "order is not ready");
+                error!(tries, "order is not ready: {state:#?}");
                 return Err(anyhow::anyhow!("order is not ready"));
             }
         }

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     // Alternatively, restore an account from serialized credentials by
     // using `Account::from_credentials()`.
 
-    let account = Account::create(
+    let (account, credentials) = Account::create(
         &NewAccount {
             contact: &[],
             terms_of_service_agreed: true,
@@ -29,6 +29,10 @@ async fn main() -> anyhow::Result<()> {
         None,
     )
     .await?;
+    info!(
+        "account credentials:\n\n{}",
+        serde_json::to_string_pretty(&credentials).unwrap()
+    );
 
     // Create the ACME order based on the given domain names.
     // Note that this only needs an `&Account`, so the library will let you
@@ -141,11 +145,6 @@ async fn main() -> anyhow::Result<()> {
 
     info!("certficate chain:\n\n{}", cert_chain_pem);
     info!("private key:\n\n{}", cert.serialize_private_key_pem());
-    info!(
-        "account credentials:\n\n{}",
-        serde_json::to_string_pretty(&account.credentials()).unwrap()
-    );
-
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,25 @@ impl Account {
         })
     }
 
+    /// Restore an existing account from the given ID, private key, server URL and HTTP client
+    ///
+    /// The key must be provided in DER-encoded PKCS#8. This is usually how ECDSA keys are
+    /// encoded in PEM files. Use a crate like rustls-pemfile to decode from PEM to DER.
+    pub async fn from_parts(
+        id: String,
+        key_pkcs8_der: &[u8],
+        directory_url: &str,
+        http: Box<dyn HttpClient>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            inner: Arc::new(AccountInner {
+                id,
+                key: Key::from_pkcs8_der(BASE64_URL_SAFE_NO_PAD.decode(key_pkcs8_der)?)?,
+                client: Client::new(directory_url, http).await?,
+            }),
+        })
+    }
+
     /// Create a new account on the `server_url` with the information in [`NewAccount`]
     ///
     /// The returned [`AccountCredentials`] can be serialized and stored for later use.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,3 +670,22 @@ where
 
 const JOSE_JSON: &str = "application/jose+json";
 const REPLAY_NONCE: &str = "Replay-Nonce";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn deserialize_old_credentials() -> Result<(), Error> {
+        const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","urls":{"newNonce":"new-nonce","newAccount":"new-acct","newOrder":"new-order"}}"#;
+        Account::from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deserialize_new_credentials() -> Result<(), Error> {
+        const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","directory":"https://acme-staging-v02.api.letsencrypt.org/directory"}"#;
+        Account::from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?).await?;
+        Ok(())
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt;
 
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
@@ -53,10 +52,11 @@ impl From<&'static str> for Error {
 /// the account credentials to a file or secret manager and restore the
 /// account from persistent storage.
 #[derive(Deserialize, Serialize)]
-pub struct AccountCredentials<'a> {
-    pub(crate) id: Cow<'a, str>,
+pub struct AccountCredentials {
+    pub(crate) id: String,
     pub(crate) key_pkcs8: String,
-    pub(crate) urls: Cow<'a, DirectoryUrls>,
+    pub(crate) directory: Option<String>,
+    pub(crate) urls: Option<DirectoryUrls>,
 }
 
 /// An RFC 7807 problem document as returned by the ACME server


### PR DESCRIPTION
Only yield `AccountCredentials` (which gives access to the private key) at `Account` creation time. Store the `directory` in the `AccountCredentials` and prefer using it to acquire new `DirectoryUrls` if available at deserialization time.