### PR TITLE
Be more lenient with challenge error field

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,8 @@ use ring::signature::{EcdsaKeyPair, KeyPair};
 use rustls_pki_types::CertificateDer;
 use serde::de::DeserializeOwned;
 use serde::ser::SerializeMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
 /// Error type for instant-acme
@@ -238,7 +239,17 @@ pub struct Challenge {
     /// Current status
     pub status: ChallengeStatus,
     /// Potential error state
+    #[serde(deserialize_with = "ok_or_none")]
     pub error: Option<Problem>,
+}
+
+fn ok_or_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let v = Value::deserialize(deserializer)?;
+    Ok(T::deserialize(v).ok())
 }
 
 /// Contents of an ACME order as described in RFC 8555 (section 7.1.3)


### PR DESCRIPTION
Zerossl appears to have started to include an empty object within the `error` field of the challenges, like so:

```
"challenges":[
  {
    "type":"http-01",
    "url":"https://acme.zerossl.com/v2/DV
90/<...>",
    "status":"invalid",
    "error":{},
    "token":"<...>"
  }
]
```

Not sure if they are behaving within spec, but failing to filter out empty body leads to instant-acme breaking on such 200 response:

```
Json(Error("missing field `type`", line: 1, column: 245))
```

I changed it so that the error field defaults to `None`, if it fails to deserialize. Ideally, you'd want to check for empty `serde_json::Value`, but alas, deserializer error types are incompatible when further deserializing `serde_json::Value`.