### PR TITLE
Make Problem fields optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0"

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,11 +108,11 @@ pub struct Problem {
     /// One of an enumerated list of problem types
     ///
     /// See <https://datatracker.ietf.org/doc/html/rfc8555#section-6.7>
-    pub r#type: String,
+    pub r#type: Option<String>,
     /// A human-readable explanation of the problem
-    pub detail: String,
+    pub detail: Option<String>,
     /// The HTTP status code returned for this response
-    pub status: u16,
+    pub status: Option<u16>,
 }
 
 impl Problem {
@@ -136,7 +136,16 @@ impl Problem {
 
 impl fmt::Display for Problem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "API error: {} ({})", self.detail, self.r#type)
+        f.write_str("API error")?;
+        if let Some(detail) = &self.detail {
+            write!(f, ": {detail}")?;
+        }
+
+        if let Some(r#type) = &self.r#type {
+            write!(f, " ({})", r#type)?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Alternative to #43. RFC 8555 says in [section 8](https://datatracker.ietf.org/doc/html/rfc8555#section-8):

> * error (optional, object):  Error that occurred while the server was validating the challenge, if any, structured as a problem document [[RFC7807](https://datatracker.ietf.org/doc/html/rfc7807)].  Multiple errors can be indicated by using subproblems [Section 6.7.1](https://datatracker.ietf.org/doc/html/rfc8555#section-6.7.1).  A challenge object with an error MUST have status equal to "invalid".

RFC 7807 in [section 3.1](https://datatracker.ietf.org/doc/html/rfc7807#section-3.1) isn't very structured about describing optionality, but it has the following bits of context (emphasis mine):

> * "type" (string) - A URI reference [[RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)] that identifies the problem type.  This specification encourages that, when dereferenced, it provide human-readable documentation for the problem type (e.g., using HTML [[W3C.REC-html5-20141028](https://datatracker.ietf.org/doc/html/rfc7807#ref-W3C.REC-html5-20141028)]).  **When this member is not present**, its value is assumed to be "about:blank".

> The "status" member, **if present,** is only advisory; it conveys the HTTP status code used for the convenience of the consumer.

> The "detail" member, **if present**, ought to focus on helping the client correct the problem, rather than giving debugging information.

Change the type definition to properly encode the optionality of these fields.