### PR TITLE
Prepare 0.7.0 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo check
+      - run: cargo check --no-default-features --features aws-lc-rs
+      - run: cargo check --no-default-features --features ring
+      - run: cargo check # hyper-rustls, ring
       - run: cargo test
-      - run: cargo test --no-default-features --features hyper-rustls,aws-lc-rs
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,14 +21,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      AWS_LC_SYS_NO_ASM: 1
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
       - run: cargo check --no-default-features --features aws-lc-rs
       - run: cargo check --no-default-features --features ring
       - run: cargo check # hyper-rustls, ring

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,15 @@ jobs:
       - run: cargo check # hyper-rustls, ring
       - run: cargo test
 
+  fips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.67.0
+      - run: cargo check --lib --features fips
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,20 @@ categories = ["web-programming", "api-bindings"]
 default = ["hyper-rustls", "ring"]
 aws-lc-rs = ["dep:aws-lc-rs", "hyper-rustls?/aws-lc-rs", "rcgen/aws_lc_rs"]
 fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
+hyper-rustls = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util"]
 ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 
 [dependencies]
+async-trait = "0.1"
 aws-lc-rs = { version = "1.8.0", optional = true }
 base64 = "0.21.0"
 bytes = "1"
 http = "1"
+http-body = "1"
 http-body-util = "0.1.2"
-hyper = { version = "1.3.1", features = ["client", "http1", "http2"] }
+hyper = { version = "1.3.1", features = ["client", "http1", "http2"], optional = true }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "tls12", "rustls-native-certs"], optional = true }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2", "tokio"], optional = true }
 ring = { version = "0.17", features = ["std"], optional = true }
 rustls-pki-types = "1.1.0"
 serde = { version = "1.0.104", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["web-programming", "api-bindings"]
 
 [features]
 default = ["hyper-rustls", "ring"]
-ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 aws-lc-rs = ["dep:aws-lc-rs", "hyper-rustls?/aws-lc-rs", "rcgen/aws_lc_rs"]
 fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
+ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 
 [dependencies]
 aws-lc-rs = { version = "1.8.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 [dependencies]
 aws-lc-rs = { version = "1.8.0", optional = true }
 base64 = "0.21.0"
+bytes = "1"
 http = "1"
 http-body-util = "0.1.2"
 hyper = { version = "1.3.1", features = ["client", "http1", "http2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.67"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 [dependencies]
 aws-lc-rs = { version = "1.8.0", optional = true }
 base64 = "0.21.0"
+http-body-util = "0.1.2"
 hyper = { version = "1.3.1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "tls12", "rustls-native-certs"], optional = true }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
-http-body-util = "0.1.2"
 ring = { version = "0.17", features = ["std"], optional = true }
 rustls-pki-types = "1.1.0"
 serde = { version = "1.0.104", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 [dependencies]
 aws-lc-rs = { version = "1.8.0", optional = true }
 base64 = "0.21.0"
+http = "1"
 http-body-util = "0.1.2"
 hyper = { version = "1.3.1", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "tls12", "rustls-native-certs"], optional = true }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,18 @@ specification.
 * Support for external account binding
 * Support for certificate revocation
 * Uses hyper with rustls and Tokio for HTTP requests
-* Uses *ring* for ECDSA signing
+* Uses *ring* or aws-lc-rs for ECDSA signing
 * Minimum supported Rust version: 1.63
+
+## Cargo features
+
+* `hyper-rustls` (default): use a hyper client with rustls
+* `ring` (default): use the *ring* crate as the crypto backend
+* `aws-lc-rs`: use the aws-lc-rs crate as the crypto backend
+* `fips`: enable the aws-lc-rs crate's FIPS-compliant mode
+
+If both `ring` and `aws-lc-rs` are enabled, which backend is used depends on the `fips` feature.
+If `fips` is enabled, `aws-lc-rs` is used; otherwise, `ring` is used.
 
 ## Limitations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,15 @@
 #![warn(unreachable_pub)]
 #![warn(missing_docs)]
 
-#[cfg(feature = "aws-lc-rs")]
-pub(crate) use aws_lc_rs as ring_like;
-#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-pub(crate) use ring as ring_like;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+
+#[cfg(feature = "aws-lc-rs")]
+pub(crate) use aws_lc_rs as ring_like;
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+pub(crate) use ring as ring_like;
 
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
 use http_body_util::{BodyExt, Full};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,9 +727,9 @@ where
 }
 
 mod crypto {
-    #[cfg(feature = "aws-lc-rs")]
+    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
     pub(crate) use aws_lc_rs as ring_like;
-    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    #[cfg(feature = "ring")]
     pub(crate) use ring as ring_like;
 
     pub(crate) use ring_like::digest::{digest, Digest, SHA256};
@@ -739,7 +739,7 @@ mod crypto {
     pub(crate) use ring_like::signature::{KeyPair, Signature};
     pub(crate) use ring_like::{hmac, pkcs8};
 
-    #[cfg(feature = "aws-lc-rs")]
+    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
     pub(crate) fn p256_key_pair_from_pkcs8(
         pkcs8: &[u8],
         _: &SystemRandom,
@@ -747,7 +747,7 @@ mod crypto {
         EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8)
     }
 
-    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    #[cfg(feature = "ring")]
     pub(crate) fn p256_key_pair_from_pkcs8(
         pkcs8: &[u8],
         rng: &SystemRandom,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+use http::header::{CONTENT_TYPE, LOCATION};
+use http::{Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
-use hyper::header::{CONTENT_TYPE, LOCATION};
-use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client as HyperClient;
 #[cfg(feature = "hyper-rustls")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,25 +552,16 @@ impl Key {
         let rng = crypto::SystemRandom::new();
         let pkcs8 =
             crypto::EcdsaKeyPair::generate_pkcs8(&crypto::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)?;
-        let inner = crypto::p256_key_pair_from_pkcs8(pkcs8.as_ref(), &rng)?;
-        let thumb = BASE64_URL_SAFE_NO_PAD.encode(Jwk::thumb_sha256(&inner)?);
-
-        Ok((
-            Self {
-                rng,
-                signing_algorithm: SigningAlgorithm::Es256,
-                inner,
-                thumb,
-            },
-            pkcs8,
-        ))
+        Self::new(pkcs8.as_ref(), rng).map(|key| (key, pkcs8))
     }
 
     fn from_pkcs8_der(pkcs8_der: &[u8]) -> Result<Self, Error> {
-        let rng = crypto::SystemRandom::new();
+        Self::new(pkcs8_der, crypto::SystemRandom::new())
+    }
+
+    fn new(pkcs8_der: &[u8], rng: crypto::SystemRandom) -> Result<Self, Error> {
         let inner = crypto::p256_key_pair_from_pkcs8(pkcs8_der, &rng)?;
         let thumb = BASE64_URL_SAFE_NO_PAD.encode(Jwk::thumb_sha256(&inner)?);
-
         Ok(Self {
             rng,
             signing_algorithm: SigningAlgorithm::Es256,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,7 @@ impl Order {
             .await?;
 
         self.nonce = nonce_from_response(&rsp);
-        let body = Problem::from_response(rsp)
-            .await?
-            .collect()
-            .await?
-            .to_bytes();
+        let body = Problem::from_response(rsp).await?;
         Ok(Some(
             String::from_utf8(body.to_vec())
                 .map_err(|_| "unable to decode certificate as UTF-8")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,9 +800,9 @@ pub trait BytesBody {
 }
 
 mod crypto {
-    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+    #[cfg(all(feature = "aws-lc-rs", any(feature = "fips", not(feature = "ring"))))]
     pub(crate) use aws_lc_rs as ring_like;
-    #[cfg(feature = "ring")]
+    #[cfg(all(feature = "ring", not(feature = "fips")))]
     pub(crate) use ring as ring_like;
 
     pub(crate) use ring_like::digest::{digest, Digest, SHA256};
@@ -812,7 +812,7 @@ mod crypto {
     pub(crate) use ring_like::signature::{KeyPair, Signature};
     pub(crate) use ring_like::{hmac, pkcs8};
 
-    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+    #[cfg(all(feature = "aws-lc-rs", any(feature = "fips", not(feature = "ring"))))]
     pub(crate) fn p256_key_pair_from_pkcs8(
         pkcs8: &[u8],
         _: &SystemRandom,
@@ -820,7 +820,7 @@ mod crypto {
         EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8)
     }
 
-    #[cfg(feature = "ring")]
+    #[cfg(all(feature = "ring", not(feature = "fips")))]
     pub(crate) fn p256_key_pair_from_pkcs8(
         pkcs8: &[u8],
         rng: &SystemRandom,

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,13 +31,13 @@ pub enum Error {
     CryptoKey(#[from] crypto::KeyRejected),
     /// HTTP failure
     #[error("HTTP request failure: {0}")]
-    Http(#[from] hyper::http::Error),
+    Http(#[from] http::Error),
     /// Hyper request failure
     #[error("HTTP request failure: {0}")]
     Hyper(#[from] hyper::Error),
     /// Invalid ACME server URL
     #[error("invalid URI: {0}")]
-    InvalidUri(#[from] hyper::http::uri::InvalidUri),
+    InvalidUri(#[from] http::uri::InvalidUri),
     /// Failed to (de)serialize a JSON object
     #[error("failed to (de)serialize JSON: {0}")]
     Json(#[from] serde_json::Error),

--- a/src/types.rs
+++ b/src/types.rs
@@ -450,15 +450,15 @@ pub enum AuthorizationStatus {
 
 /// Represent an identifier in an ACME [Order](crate::Order)
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Identifier {
     Dns(String),
 }
 
 /// The challenge type
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[allow(missing_docs)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub enum ChallengeType {
     #[serde(rename = "http-01")]
     Http01,
@@ -466,6 +466,8 @@ pub enum ChallengeType {
     Dns01,
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,12 +2,13 @@ use std::fmt;
 
 #[cfg(feature = "aws-lc-rs")]
 pub(crate) use aws_lc_rs as ring_like;
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+pub(crate) use ring as ring_like;
+
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use hyper::Response;
-#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-pub(crate) use ring as ring_like;
 use ring_like::digest::{digest, Digest, SHA256};
 use ring_like::signature::{EcdsaKeyPair, KeyPair};
 use rustls_pki_types::CertificateDer;


### PR DESCRIPTION
* Followup from #56 to clean things up a bit
* Cleanup from #50 
* Restore ability to build `HttpClient` implementations without hyper (after #50)
* Incorporate #54 (fixes #51)