### PR TITLE
Yield Break from RetryState::wait() on last iteration

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::net::IpAddr;
+use std::time::Instant;
 
 use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
 use bytes::Bytes;
@@ -51,6 +52,11 @@ pub enum Error {
     /// Failed to (de)serialize a JSON object
     #[error("failed to (de)serialize JSON: {0}")]
     Json(#[from] serde_json::Error),
+    /// Timed out while waiting for the server to update [`OrderStatus`]
+    ///
+    /// If `Some`, the nested `Instant` indicates when the server suggests to poll next.
+    #[error("timed out waiting for an order update")]
+    Timeout(Option<Instant>),
     /// ACME server does not support a requested feature
     #[error("ACME server does not support: {0}")]
     Unsupported(&'static str),


### PR DESCRIPTION
As suggested by @christianhoelzl in https://github.com/djc/instant-acme/pull/116#discussion_r2174781560:

> One option is to preemptively end the retry if the next iteration would exceed the timeout. This is how [acme4j ](https://github.com/shred/acme4j/blob/2a5df329bdc34165f0f8f2c51c75a643e07aabb6/acme4j-client/src/main/java/org/shredzone/acme4j/PollableResource.java#L95)does it.

Doesn't really solve the original problem I highlighted, let's discuss here:

> Uhh, not sure how this interaction [between timeout and retry-after] will work? Seems like a strong chance the server might yield a Retry-After of more than the timeout set here, which means we'll only ever try once...