### PR TITLE
Add Account::key_thumbprint() for convenience

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -297,7 +297,7 @@ impl Account {
         &self.inner.id
     }
 
-    /// Get the account key_thumbprint
+    /// Get the [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) account key thumbprint
     pub fn key_thumbprint(&self) -> &str {
         &self.inner.key.thumb
     }


### PR DESCRIPTION
In my case, I need to get account key thumb, for quick http-01 challenge （for Lets Encrypt）
here is my example

```rust

#[get("/.well-known/acme-challenge/{token}")]
async fn handle_acme_challenge(token: web::Path<String>) -> impl Responder {
      let thumb = ACCOUNT.key_thumbprint();  // ACCOUNT is an instance of instant-acme::Account
      HttpResponseBuilder::new(StatusCode::OK)
        .content_type("text/plain")
        .body(format!(
            "{}.{}",
            token.into_inner(),
            thumb
        ))
}
```