### PR TITLE
Carefully lint default feature configurations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --no-default-features --features ring -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   docs:

--- a/src/account.rs
+++ b/src/account.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "hyper-rustls")]
 use crate::DefaultClient;
 use crate::order::Order;
+#[cfg(feature = "time")]
+use crate::retry_after;
 use crate::types::{
     AccountCredentials, AuthorizationStatus, Empty, Header, JoseJson, Jwk, KeyOrKeyId, NewAccount,
     NewAccountPayload, NewOrder, OrderState, Problem, ProfileMeta, RevocationRequest, Signer,
@@ -22,7 +24,7 @@ use crate::types::{
 };
 #[cfg(feature = "time")]
 use crate::types::{CertificateIdentifier, RenewalInfo};
-use crate::{BytesResponse, Client, Error, HttpClient, crypto, nonce_from_response, retry_after};
+use crate::{BytesResponse, Client, Error, HttpClient, crypto, nonce_from_response};
 
 /// An ACME account as described in RFC 8555 (section 7.1.2)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ mod crypto {
 const JOSE_JSON: &str = "application/jose+json";
 const REPLAY_NONCE: &str = "Replay-Nonce";
 
-#[cfg(test)]
+#[cfg(all(test, feature = "hyper-rustls"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
#125 left a warning under not `--all-features` conditions:

```rust
warning: unused import: `retry_after`
  --> src/account.rs:25:84
   |
25 | ...lient, crypto, nonce_from_response, retry_after};
   |                                        ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```