### PR TITLE
account: support default client w/ custom root CA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["web-programming", "api-bindings"]
 default = ["aws-lc-rs", "hyper-rustls"]
 aws-lc-rs = ["dep:aws-lc-rs", "hyper-rustls?/aws-lc-rs", "rcgen/aws_lc_rs"]
 fips = ["aws-lc-rs", "aws-lc-rs?/fips"]
-hyper-rustls = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util"]
+hyper-rustls = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:rustls"]
 rcgen = ["dep:rcgen"]
 ring = ["dep:ring", "hyper-rustls?/ring", "rcgen/ring"]
 time = ["dep:time"]
@@ -35,6 +35,7 @@ hyper-rustls = { version = "0.27.7", default-features = false, features = ["http
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2", "tokio"], optional = true }
 rcgen = { version = "0.14", default-features = false, features = ["pem"], optional = true }
 ring = { version = "0.17", features = ["std"], optional = true }
+rustls = { version = "0.23", default-features = false, optional = true }
 rustls-pki-types = "1.1.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.78"


### PR DESCRIPTION
Possible alternative to https://github.com/djc/instant-acme/pull/128
Fixes https://github.com/djc/instant-acme/issues/127

Adjusting the Pebble tests to benefit from this constructor will take some additional work. We want to be able to store a pre-configured client in the env to use outside of `Account` actions (e.g. in `Environment::issuer_roots()` to fetch issuer roots).