### PR TITLE
cargo-audit: ignore RUSTSEC-2026-0009

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,11 @@
 [advisories]
 yanked = "deny"
+ignore = [
+  # RUSTSEC-2026-0009: Vulnerability in time
+  #   Not applicable - `instant-acme` only parses RFC-3339 dates from a trusted
+  #   source (the ACME server). Updating `time` requires an MSRV bump.
+  "RUSTSEC-2026-0009"
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
Follow-up to https://github.com/djc/instant-acme/pull/248

Ignores [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009.html) for the reasons discussed in #248 and the associated comment in the `audit.toml` file. We can remove this with a future MSRV update to 1.88+.