### PR TITLE
fix: send_device_attestation yields challenge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If both `ring` and `aws-lc-rs` are enabled, `aws-lc-rs` will be used.
 ## Limitations
 
 * Only supports P-256 ECDSA account keys for now
+* Device attestation support is experimental
 
 ## Getting started
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -465,6 +465,8 @@ impl ChallengeHandle<'_> {
     ///
     /// The function yields the challenge status from the ACME server that validated the
     /// attestation challenge.
+    ///
+    /// Note: Device attestation support is experimental.
     pub async fn send_device_attestation(
         &mut self,
         payload: &DeviceAttestation<'_>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -724,6 +724,7 @@ pub enum ChallengeType {
     Dns01,
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
+    /// Note: Device attestation support is experimental
     #[serde(rename = "device-attest-01")]
     DeviceAttest01,
     #[serde(untagged)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -730,6 +730,7 @@ pub enum ChallengeType {
     Unknown(String),
 }
 
+/// Status of an ACME [Challenge]
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
The pull request extends the function `send_device_attestation`. It yields the `ChallengeStatus` instead of an empty success result. This is useful to check if the attestation object was validated by the ACME CA immediately after sending the attestation object.