### PR TITLE
fix: send_device_attestation encoding of attestation objects

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -470,8 +470,14 @@ impl ChallengeHandle<'_> {
             return Err(Error::Str("challenge type should be device-attest-01"));
         }
 
-        let payload = DeviceAttestation {
-            att_obj: Cow::Owned(BASE64_URL_SAFE_NO_PAD.encode(&payload.att_obj).into()),
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct DeviceAttestationBase64<'a> {
+            att_obj: Cow<'a, str>,
+        }
+
+        let payload = DeviceAttestationBase64 {
+            att_obj: Cow::Owned(BASE64_URL_SAFE_NO_PAD.encode(&payload.att_obj)),
         };
 
         let rsp = self

--- a/src/types.rs
+++ b/src/types.rs
@@ -956,10 +956,8 @@ pub(crate) enum SigningAlgorithm {
 /// Attestation payload used for device-attest-01
 ///
 /// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct DeviceAttestation<'a> {
-    /// attestation payload
+    /// CBOR encoded attestation payload
     pub att_obj: Cow<'a, [u8]>,
 }
 


### PR DESCRIPTION
This pull request fixes the function `send_device_attestation`. Any binary (CBOR encoded) attestation object `DeviceAttestation::att_obj` is now sent as an base64 encoded string to the ACME CA, not as an array anymore. I successfully tested this change with Step CA. Some obsolete annotations are removed from the public `DeviceAttestation` struct.