### PR TITLE
Allow library users to bring their own crypto providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ tracing-subscriber =  { version = "0.3.16", features = ["env-filter"] }
 name = "provision"
 required-features = ["hyper-rustls", "rcgen", "aws-lc-rs"]
 
+[[example]]
+name = "certgen"
+required-features = ["rcgen", "aws-lc-rs"]
+
 # Pebble integration test.
 # Ignored by default because it requires pebble & pebble-challtestsrv.
 # Run with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tracing-subscriber =  { version = "0.3.16", features = ["env-filter"] }
 
 [[example]]
 name = "provision"
-required-features = ["hyper-rustls", "rcgen"]
+required-features = ["hyper-rustls", "rcgen", "aws-lc-rs"]
 
 # Pebble integration test.
 # Ignored by default because it requires pebble & pebble-challtestsrv.
@@ -63,7 +63,7 @@ required-features = ["hyper-rustls", "rcgen"]
 #  PEBBLE=path/to/pebble CHALLTESTSRV=path/to/pebble-challtestsrv cargo test -- --ignored
 [[test]]
 name = "pebble"
-required-features = ["hyper-rustls"]
+required-features = ["hyper-rustls", "rcgen"]
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.70"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ allowed_external_types = [
     "http::*",
     "http_body::*",
     "hyper::*",
+    "rustls::crypto::CryptoProvider",
     "rustls_pki_types::*",
     "serde_core::*",
     "serde_json::*",

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -2,12 +2,12 @@
 use std::io;
 
 use clap::Parser;
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::CryptoProvider as RustlsCryptoProvider;
 use tracing::info;
 
 use instant_acme::{
-    Account, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder,
-    OrderStatus, RetryPolicy,
+    Account, AuthorizationStatus, ChallengeType, CryptoProvider, Identifier, LetsEncrypt,
+    NewAccount, NewOrder, OrderStatus, RetryPolicy,
 };
 
 #[tokio::main]
@@ -19,7 +19,13 @@ async fn main() -> anyhow::Result<()> {
     // Alternatively, restore an account from serialized credentials by
     // using `Account::from_credentials()`.
 
-    let (account, credentials) = Account::builder(rustls_crypto_provider())?
+    #[cfg(feature = "aws-lc-rs")]
+    let provider = CryptoProvider::aws_lc_rs();
+
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    let provider = CryptoProvider::ring();
+
+    let (account, credentials) = Account::builder(provider, rustls_crypto_provider())?
         .create(
             &NewAccount {
                 contact: &[],
@@ -73,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
         println!(
             "_acme-challenge.{} IN TXT {}",
             challenge.identifier(),
-            challenge.key_authorization().dns_value()
+            challenge.key_authorization()?.dns_value()
         );
         io::stdin().read_line(&mut String::new())?;
 
@@ -104,11 +110,11 @@ struct Options {
 }
 
 #[cfg(feature = "aws-lc-rs")]
-fn rustls_crypto_provider() -> CryptoProvider {
+fn rustls_crypto_provider() -> RustlsCryptoProvider {
     rustls::crypto::aws_lc_rs::default_provider()
 }
 
 #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-fn rustls_crypto_provider() -> CryptoProvider {
+fn rustls_crypto_provider() -> RustlsCryptoProvider {
     rustls::crypto::ring::default_provider()
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -235,7 +235,7 @@ impl Account {
             old_key: Jwk<'a>,
         }
 
-        let (new_key, new_key_pkcs8) = Key::generate_pkcs8()?;
+        let (new_key, new_key_pkcs8) = Key::generate()?;
         let mut header = new_key.header(Some("nonce"), new_key_url);
         header.nonce = None;
         let payload = NewKey {
@@ -440,7 +440,7 @@ impl AccountBuilder {
         directory_url: String,
         external_account: Option<&ExternalAccountKey>,
     ) -> Result<(Account, AccountCredentials), Error> {
-        let (key, key_pkcs8) = Key::generate_pkcs8()?;
+        let (key, key_pkcs8) = Key::generate()?;
         Self::create_inner(
             account,
             (key, key_pkcs8),
@@ -590,14 +590,7 @@ pub struct Key {
 
 impl Key {
     /// Generate a new ECDSA P-256 key pair
-    #[deprecated(since = "0.8.3", note = "use `generate_pkcs8()` instead")]
-    pub fn generate() -> Result<(Self, PrivateKeyDer<'static>), Error> {
-        let (key, pkcs8) = Self::generate_pkcs8()?;
-        Ok((key, PrivateKeyDer::Pkcs8(pkcs8)))
-    }
-
-    /// Generate a new ECDSA P-256 key pair
-    pub fn generate_pkcs8() -> Result<(Self, PrivatePkcs8KeyDer<'static>), Error> {
+    pub fn generate() -> Result<(Self, PrivatePkcs8KeyDer<'static>), Error> {
         let rng = crypto::SystemRandom::new();
         let pkcs8 =
             crypto::EcdsaKeyPair::generate_pkcs8(&crypto::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)

--- a/src/account.rs
+++ b/src/account.rs
@@ -232,7 +232,7 @@ impl Account {
         struct NewKey<'a> {
             account: &'a str,
             #[serde(rename = "oldKey")]
-            old_key: Jwk,
+            old_key: Jwk<'a>,
         }
 
         let (new_key, new_key_pkcs8) = Key::generate_pkcs8()?;
@@ -617,7 +617,7 @@ impl Key {
 
     fn new(pkcs8_der: &[u8], rng: crypto::SystemRandom) -> Result<Self, Error> {
         let inner = crypto::p256_key_pair_from_pkcs8(pkcs8_der, &rng)?;
-        let thumb = BASE64_URL_SAFE_NO_PAD.encode(Jwk::thumb_sha256(&inner)?);
+        let thumb = BASE64_URL_SAFE_NO_PAD.encode(Jwk::new(&inner).thumb_sha256()?);
         Ok(Self {
             rng,
             signing_algorithm: SigningAlgorithm::Es256,

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "hyper-rustls")]
 use std::path::Path;
 use std::sync::Arc;
+
 #[cfg(feature = "time")]
 use std::time::{Duration, SystemTime};
 
@@ -11,30 +12,29 @@ use http::header::USER_AGENT;
 #[cfg(feature = "time")]
 use http::{Method, Request};
 #[cfg(feature = "hyper-rustls")]
-use rustls::RootCertStore;
+use rustls::{RootCertStore, crypto::CryptoProvider as RustlsCryptoProvider};
 #[cfg(feature = "hyper-rustls")]
-use rustls::crypto::CryptoProvider;
-#[cfg(feature = "hyper-rustls")]
-use rustls_pki_types::CertificateDer;
-#[cfg(feature = "hyper-rustls")]
-use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, pem::PemObject};
 use rustls_pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "hyper-rustls")]
 use crate::DefaultClient;
+use crate::crypto::HmacKey;
+#[cfg(doc)]
+use crate::crypto::HmacKeyProvider;
+use crate::crypto::{CryptoProvider, SigningKey};
 use crate::order::Order;
 use crate::types::{
     AccountCredentials, AuthorizationStatus, Empty, Header, JoseJson, Jwk, KeyOrKeyId, NewAccount,
     NewAccountPayload, NewOrder, OrderState, Problem, ProfileMeta, RevocationRequest, Signer,
-    SigningAlgorithm,
 };
 #[cfg(feature = "time")]
 use crate::types::{CertificateIdentifier, RenewalInfo};
 #[cfg(feature = "time")]
 use crate::{BodyWrapper, CRATE_USER_AGENT, retry_after};
-use crate::{BytesResponse, Client, Error, HttpClient, crypto, nonce_from_response};
+use crate::{BytesResponse, Client, Error, HttpClient, nonce_from_response};
 
 /// An ACME account as described in RFC 8555 (section 7.1.2)
 ///
@@ -52,11 +52,18 @@ pub struct Account {
 }
 
 impl Account {
-    /// Create an account builder with the default HTTP client
+    /// Create an account builder with the given [`CryptoProvider`] and default HTTP client
+    ///
+    /// The `rustls_crypto_provider` configures TLS for the HTTPS connection to the
+    /// ACME server and is separate from the ACME-level [`CryptoProvider`].
     #[cfg(feature = "hyper-rustls")]
-    pub fn builder(rustls_crypto_provider: CryptoProvider) -> Result<AccountBuilder, Error> {
+    pub fn builder(
+        provider: &'static CryptoProvider,
+        rustls_crypto_provider: RustlsCryptoProvider,
+    ) -> Result<AccountBuilder, Error> {
         Ok(AccountBuilder {
             http: Box::new(DefaultClient::try_new(rustls_crypto_provider)?),
+            provider,
         })
     }
 
@@ -67,7 +74,8 @@ impl Account {
     #[cfg(feature = "hyper-rustls")]
     pub fn builder_with_root(
         pem_path: impl AsRef<Path>,
-        rustls_crypto_provider: CryptoProvider,
+        provider: &'static CryptoProvider,
+        rustls_crypto_provider: RustlsCryptoProvider,
     ) -> Result<AccountBuilder, Error> {
         let root_der = match CertificateDer::from_pem_file(pem_path) {
             Ok(root_der) => root_der,
@@ -78,14 +86,18 @@ impl Account {
         match roots.add(root_der) {
             Ok(()) => Ok(AccountBuilder {
                 http: Box::new(DefaultClient::with_roots(roots, rustls_crypto_provider)?),
+                provider,
             }),
             Err(err) => Err(Error::Other(err.into())),
         }
     }
 
-    /// Create an account builder with the given HTTP client
-    pub fn builder_with_http(http: Box<dyn HttpClient>) -> AccountBuilder {
-        AccountBuilder { http }
+    /// Create an account builder with the given [`CryptoProvider`] and HTTP client
+    pub fn builder_with_http(
+        http: Box<dyn HttpClient>,
+        provider: &'static CryptoProvider,
+    ) -> AccountBuilder {
+        AccountBuilder { http, provider }
     }
 
     /// Create a new order based on the given [`NewOrder`]
@@ -235,12 +247,12 @@ impl Account {
             old_key: Jwk<'a>,
         }
 
-        let (new_key, new_key_pkcs8) = Key::generate()?;
+        let (new_key, new_key_pkcs8) = Key::generate(self.inner.key.provider)?;
         let mut header = new_key.header(Some("nonce"), new_key_url);
         header.nonce = None;
         let payload = NewKey {
             account: &self.inner.id,
-            old_key: Jwk::new(&self.inner.key.inner),
+            old_key: self.inner.key.inner.as_jwk(),
         };
 
         let body = JoseJson::new(Some(&payload), header, &new_key)?;
@@ -343,8 +355,8 @@ impl Account {
     }
 
     /// Get the [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) account key thumbprint
-    pub fn key_thumbprint(&self) -> &str {
-        &self.inner.key.thumb
+    pub fn key_thumbprint(&self) -> Result<String, Error> {
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(self.inner.key.thumb_sha256()?))
     }
 }
 
@@ -358,10 +370,11 @@ impl AccountInner {
     async fn from_credentials(
         credentials: AccountCredentials,
         http: Box<dyn HttpClient>,
+        provider: &'static CryptoProvider,
     ) -> Result<Self, Error> {
         Ok(Self {
             id: credentials.id,
-            key: Key::from_pkcs8_der(credentials.key_pkcs8)?,
+            key: Key::from_pkcs8_der(credentials.key_pkcs8, provider)?,
             client: Arc::new(match (credentials.directory, credentials.urls) {
                 (Some(directory_url), _) => Client::new(directory_url, http).await?,
                 (None, Some(directory)) => Client {
@@ -395,12 +408,12 @@ impl AccountInner {
 }
 
 impl Signer for AccountInner {
-    type Signature = <Key as Signer>::Signature;
+    type Signature = Vec<u8>;
 
     fn header<'n, 'u: 'n, 's: 'u>(&'s self, nonce: Option<&'n str>, url: &'u str) -> Header<'n> {
         debug_assert!(nonce.is_some());
         Header {
-            alg: self.key.signing_algorithm,
+            alg: self.key.inner.jws_algorithm(),
             key: KeyOrKeyId::KeyId(&self.id),
             nonce,
             url,
@@ -408,7 +421,7 @@ impl Signer for AccountInner {
     }
 
     fn sign(&self, payload: &[u8]) -> Result<Self::Signature, Error> {
-        self.key.sign(payload)
+        self.key.inner.sign(payload)
     }
 }
 
@@ -417,6 +430,7 @@ impl Signer for AccountInner {
 /// Create one via [`Account::builder()`] or [`Account::builder_with_http()`].
 pub struct AccountBuilder {
     http: Box<dyn HttpClient>,
+    provider: &'static CryptoProvider,
 }
 
 impl AccountBuilder {
@@ -426,7 +440,9 @@ impl AccountBuilder {
     #[allow(clippy::wrong_self_convention)]
     pub async fn from_credentials(self, credentials: AccountCredentials) -> Result<Account, Error> {
         Ok(Account {
-            inner: Arc::new(AccountInner::from_credentials(credentials, self.http).await?),
+            inner: Arc::new(
+                AccountInner::from_credentials(credentials, self.http, self.provider).await?,
+            ),
         })
     }
 
@@ -440,7 +456,7 @@ impl AccountBuilder {
         directory_url: String,
         external_account: Option<&ExternalAccountKey>,
     ) -> Result<(Account, AccountCredentials), Error> {
-        let (key, key_pkcs8) = Key::generate()?;
+        let (key, key_pkcs8) = Key::generate(self.provider)?;
         Self::create_inner(
             account,
             (key, key_pkcs8),
@@ -517,7 +533,7 @@ impl AccountBuilder {
         Ok(Account {
             inner: Arc::new(AccountInner {
                 id,
-                key: Key::from_pkcs8_der(key_pkcs8_der)?,
+                key: Key::from_pkcs8_der(key_pkcs8_der, self.provider)?,
                 client: Arc::new(Client::new(directory_url, self.http).await?),
             }),
         })
@@ -534,7 +550,7 @@ impl AccountBuilder {
             external_account_binding: external_account
                 .map(|eak| {
                     JoseJson::new(
-                        Some(&Jwk::new(&key.inner)),
+                        Some(&key.inner.as_jwk()),
                         eak.header(None, &client.directory.new_account),
                         eak,
                     )
@@ -582,61 +598,64 @@ impl AccountBuilder {
 
 /// Private account key used to sign requests
 pub struct Key {
-    rng: crypto::SystemRandom,
-    signing_algorithm: SigningAlgorithm,
-    inner: crypto::EcdsaKeyPair,
-    pub(crate) thumb: String,
+    pub(crate) inner: Box<dyn SigningKey>,
+    pub(crate) provider: &'static CryptoProvider,
 }
 
 impl Key {
-    /// Generate a new ECDSA P-256 key pair
-    pub fn generate() -> Result<(Self, PrivatePkcs8KeyDer<'static>), Error> {
-        let rng = crypto::SystemRandom::new();
-        let pkcs8 =
-            crypto::EcdsaKeyPair::generate_pkcs8(&crypto::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
-                .map_err(|_| Error::Crypto)?;
+    /// Generate a new key pair using the given [`CryptoProvider`]
+    ///
+    /// The key type depends on the provider.
+    pub fn generate(
+        provider: &'static CryptoProvider,
+    ) -> Result<(Self, PrivatePkcs8KeyDer<'static>), Error> {
+        let (key, pkcs8) = provider.signing_key.generate_key()?;
         Ok((
-            Self::new(pkcs8.as_ref(), rng)?,
-            PrivatePkcs8KeyDer::from(pkcs8.as_ref().to_vec()),
+            Self {
+                inner: key,
+                provider,
+            },
+            pkcs8,
         ))
     }
 
-    /// Create a new key from the given PKCS#8 DER-encoded private key
-    ///
-    /// Currently, only ECDSA P-256 keys are supported.
-    pub fn from_pkcs8_der(pkcs8_der: PrivatePkcs8KeyDer<'_>) -> Result<Self, Error> {
-        Self::new(pkcs8_der.secret_pkcs8_der(), crypto::SystemRandom::new())
+    pub(crate) fn thumb_sha256(&self) -> Result<[u8; 32], Error> {
+        self.inner
+            .as_jwk()
+            .thumb_sha256(self.provider.sha256)
+            .map_err(Error::Json)
     }
 
-    fn new(pkcs8_der: &[u8], rng: crypto::SystemRandom) -> Result<Self, Error> {
-        let inner = crypto::p256_key_pair_from_pkcs8(pkcs8_der, &rng)?;
-        let thumb = BASE64_URL_SAFE_NO_PAD.encode(Jwk::new(&inner).thumb_sha256()?);
+    /// Create a key from the given PKCS#8 DER-encoded private key using the given
+    /// [`CryptoProvider`]
+    pub fn from_pkcs8_der(
+        pkcs8_der: PrivatePkcs8KeyDer<'_>,
+        provider: &'static CryptoProvider,
+    ) -> Result<Self, Error> {
+        let owned = PrivatePkcs8KeyDer::from(pkcs8_der.secret_pkcs8_der().to_vec());
+        let key = provider.signing_key.load_key(owned)?;
         Ok(Self {
-            rng,
-            signing_algorithm: SigningAlgorithm::Es256,
-            inner,
-            thumb,
+            inner: key,
+            provider,
         })
     }
 }
 
 impl Signer for Key {
-    type Signature = crypto::Signature;
+    type Signature = Vec<u8>;
 
     fn header<'n, 'u: 'n, 's: 'u>(&'s self, nonce: Option<&'n str>, url: &'u str) -> Header<'n> {
         debug_assert!(nonce.is_some());
         Header {
-            alg: self.signing_algorithm,
-            key: KeyOrKeyId::from_key(&self.inner),
+            alg: self.inner.jws_algorithm(),
+            key: KeyOrKeyId::Key(self.inner.as_jwk()),
             nonce,
             url,
         }
     }
 
     fn sign(&self, payload: &[u8]) -> Result<Self::Signature, Error> {
-        self.inner
-            .sign(&self.rng, payload)
-            .map_err(|_| Error::Crypto)
+        self.inner.sign(payload)
     }
 }
 
@@ -645,29 +664,26 @@ impl Signer for Key {
 /// See RFC 8555 section 7.3.4 for more information.
 pub struct ExternalAccountKey {
     id: String,
-    key: crypto::hmac::Key,
+    hmac_key: Box<dyn HmacKey>,
 }
 
 impl ExternalAccountKey {
-    /// Create a new external account key
+    /// Create a new external account key with the given HMAC key
     ///
-    /// Note that the `key_value` argument represents the raw key value, so if the caller holds
-    /// an encoded key value (for example, using base64), decode it before passing it in.
-    pub fn new(id: String, key_value: &[u8]) -> Self {
-        Self {
-            id,
-            key: crypto::hmac::Key::new(crypto::hmac::HMAC_SHA256, key_value),
-        }
+    /// Use [`HmacKeyProvider::load_key()`] (e.g. via [`CryptoProvider::hmac`]) to create the
+    /// key from raw key bytes.
+    pub fn new(id: String, hmac_key: Box<dyn HmacKey>) -> Self {
+        Self { id, hmac_key }
     }
 }
 
 impl Signer for ExternalAccountKey {
-    type Signature = crypto::hmac::Tag;
+    type Signature = Vec<u8>;
 
     fn header<'n, 'u: 'n, 's: 'u>(&'s self, nonce: Option<&'n str>, url: &'u str) -> Header<'n> {
         debug_assert_eq!(nonce, None);
         Header {
-            alg: SigningAlgorithm::Hs256,
+            alg: self.hmac_key.algorithm(),
             key: KeyOrKeyId::KeyId(&self.id),
             nonce,
             url,
@@ -675,6 +691,6 @@ impl Signer for ExternalAccountKey {
     }
 
     fn sign(&self, payload: &[u8]) -> Result<Self::Signature, Error> {
-        Ok(crypto::hmac::sign(&self.key, payload))
+        Ok(self.hmac_key.sign(payload))
     }
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -227,15 +227,31 @@ impl Account {
         Ok((Problem::check::<RenewalInfo>(rsp).await?, delay))
     }
 
-    /// Update the account's authentication key
+    /// Update the account's authentication key, reusing the existing [`CryptoProvider`]
     ///
     /// This is useful if you want to change the ACME account key of an existing account, e.g.
     /// to mitigate the risk of a key compromise. This method creates a new client key and changes
     /// the key associated with the existing account. `self` will be updated with the new key,
     /// and a fresh set of [`AccountCredentials`] will be returned to update stored credentials.
     ///
+    /// To change the key type (e.g. from P-256 to Ed25519), use
+    /// [`update_key_with_provider()`][Self::update_key_with_provider] instead.
+    ///
     /// See <https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.5> for more information.
     pub async fn update_key(&mut self) -> Result<AccountCredentials, Error> {
+        self.update_key_with_provider(self.inner.key.provider).await
+    }
+
+    /// Update the account's authentication key using the given [`CryptoProvider`]
+    ///
+    /// Like [`update_key()`][Self::update_key], but allows switching to a different key type
+    /// by supplying a different [`CryptoProvider`] (e.g. migrating from P-256 to Ed25519).
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.5> for more information.
+    pub async fn update_key_with_provider(
+        &mut self,
+        provider: &'static CryptoProvider,
+    ) -> Result<AccountCredentials, Error> {
         let Some(new_key_url) = self.inner.client.directory.key_change.as_deref() else {
             return Err("Account key rollover not supported by ACME CA".into());
         };
@@ -247,7 +263,7 @@ impl Account {
             old_key: Jwk<'a>,
         }
 
-        let (new_key, new_key_pkcs8) = Key::generate(self.inner.key.provider)?;
+        let (new_key, new_key_pkcs8) = Key::generate(provider)?;
         let mut header = new_key.header(Some("nonce"), new_key_url);
         header.nonce = None;
         let payload = NewKey {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,124 @@
+use std::fmt;
+
+use rustls_pki_types::PrivatePkcs8KeyDer;
+
+use crate::Error;
+use crate::types::{Jwk, SigningAlgorithm};
+
+#[cfg(feature = "aws-lc-rs")]
+mod aws_lc_rs;
+
+#[cfg(feature = "ring")]
+mod ring;
+
+/// Cryptographic provider for ACME protocol operations.
+///
+/// This handles ACME-specific crypto: JWS signing, JWK thumbprints, and EAB HMAC.
+/// It is unrelated to the rustls [`CryptoProvider`][rustls_provider], which handles TLS
+/// for the HTTPS connection to the ACME server.
+///
+/// Use [`CryptoProvider::aws_lc_rs()`] or [`CryptoProvider::ring()`] for a built-in backend,
+/// or populate the fields manually for a custom backend.
+///
+/// [rustls_provider]: rustls::crypto::CryptoProvider
+pub struct CryptoProvider {
+    /// Load and generate signing keys.
+    pub signing_key: &'static dyn SigningKeyProvider,
+    /// SHA-256 hash for ACME protocol operations.
+    ///
+    /// Used for JWK thumbprints ([RFC 7638]) and challenge digests ([RFC 8555 section 8.1]).
+    /// This is independent of the signing algorithm used for account keys.
+    ///
+    /// [RFC 7638]: https://www.rfc-editor.org/rfc/rfc7638
+    /// [RFC 8555 section 8.1]: https://www.rfc-editor.org/rfc/rfc8555#section-8.1
+    pub sha256: &'static dyn Sha256,
+    /// HMAC key provider for External Account Binding.
+    ///
+    /// See [RFC 8555 section 7.3.4].
+    ///
+    /// [RFC 8555 section 7.3.4]: https://www.rfc-editor.org/rfc/rfc8555#section-7.3.4
+    pub hmac: &'static dyn HmacKeyProvider,
+}
+
+impl CryptoProvider {
+    /// A `CryptoProvider` using ECDSA P-256 account keys backed by aws-lc-rs.
+    #[cfg(feature = "aws-lc-rs")]
+    pub fn aws_lc_rs() -> &'static Self {
+        aws_lc_rs::PROVIDER
+    }
+
+    /// A `CryptoProvider` using ECDSA P-256 account keys backed by ring.
+    #[cfg(feature = "ring")]
+    pub fn ring() -> &'static Self {
+        ring::PROVIDER
+    }
+}
+
+impl fmt::Debug for CryptoProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CryptoProvider").finish_non_exhaustive()
+    }
+}
+
+/// Load existing account keys and generate new ones.
+///
+/// Implementations are backend-specific (ring, aws-lc-rs, openssl, etc.)
+/// and key-type-specific (P-256, Ed25519, RSA, etc.).
+pub trait SigningKeyProvider: Send + Sync {
+    /// Load a signing key from PKCS#8 DER encoding.
+    fn load_key(&self, pkcs8: PrivatePkcs8KeyDer<'static>) -> Result<Box<dyn SigningKey>, Error>;
+
+    /// Generate a new key pair, returning the key and its PKCS#8 DER encoding.
+    fn generate_key(&self) -> Result<(Box<dyn SigningKey>, PrivatePkcs8KeyDer<'static>), Error>;
+}
+
+/// A signing key for ACME account operations.
+///
+/// Bundles signing, JWS algorithm identification, and JWK serialization.
+/// Implement this trait to support any key type (P-256, P-384, Ed25519, RSA, etc.)
+/// without changes to instant-acme.
+pub trait SigningKey: Send + Sync {
+    /// Sign the given data using this key's algorithm.
+    ///
+    /// The implementation handles hashing internally where required
+    /// (e.g., SHA-256 for ES256, SHA-512 for Ed25519).
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Error>;
+
+    /// The JWS `alg` header value (e.g., `ES256`).
+    fn jws_algorithm(&self) -> SigningAlgorithm;
+
+    /// Serialize the public key as a JWK JSON object for the `jwk` JWS header.
+    fn as_jwk(&self) -> Jwk<'_>;
+}
+
+/// SHA-256 hash function for ACME protocol operations.
+///
+/// Used for JWK thumbprints ([RFC 7638]) and challenge digests ([RFC 8555]).
+///
+/// [RFC 7638]: https://www.rfc-editor.org/rfc/rfc7638
+/// [RFC 8555]: https://www.rfc-editor.org/rfc/rfc8555
+pub trait Sha256: Send + Sync {
+    /// Compute the SHA-256 digest of the given data.
+    fn hash(&self, data: &[u8]) -> [u8; 32];
+}
+
+/// Provider for creating HMAC keys used in ACME External Account Binding.
+///
+/// See [RFC 8555 section 7.3.4] and the [IANA JOSE algorithms registry]
+/// for the supported HMAC algorithms (HS256, HS384, HS512).
+///
+/// [RFC 8555 section 7.3.4]: https://www.rfc-editor.org/rfc/rfc8555#section-7.3.4
+/// [IANA JOSE algorithms registry]: https://www.iana.org/assignments/jose/web-signature-encryption-algorithms.csv
+pub trait HmacKeyProvider: Send + Sync {
+    /// Create an HMAC key from the given raw key value.
+    fn load_key(&self, key_value: &[u8]) -> Box<dyn HmacKey>;
+}
+
+/// An HMAC key for signing External Account Binding payloads.
+pub trait HmacKey: Send + Sync {
+    /// The JWS `alg` header value for this key (e.g., `Hs256`).
+    fn algorithm(&self) -> SigningAlgorithm;
+
+    /// Compute the HMAC of `data` using this key.
+    fn sign(&self, data: &[u8]) -> Vec<u8>;
+}

--- a/src/crypto/aws_lc_rs.rs
+++ b/src/crypto/aws_lc_rs.rs
@@ -1,0 +1,95 @@
+use rustls_pki_types::PrivatePkcs8KeyDer;
+
+use aws_lc_rs::rand::SystemRandom;
+use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
+use aws_lc_rs::{digest, hmac};
+
+use super::{HmacKey, HmacKeyProvider, SigningKey, SigningKeyProvider};
+use crate::Error;
+use crate::types::{Jwk, JwkThumbFields, SigningAlgorithm};
+
+pub(crate) static PROVIDER: &super::CryptoProvider = &super::CryptoProvider {
+    signing_key: &P256SigningKeyProvider,
+    sha256: &Sha256,
+    hmac: &HmacSha256Provider,
+};
+
+struct P256SigningKeyProvider;
+
+impl SigningKeyProvider for P256SigningKeyProvider {
+    fn load_key(&self, pkcs8: PrivatePkcs8KeyDer<'static>) -> Result<Box<dyn SigningKey>, Error> {
+        let rng = SystemRandom::new();
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.secret_pkcs8_der())
+                .map_err(|_| Error::KeyRejected)?;
+        Ok(Box::new(P256Key { key_pair, rng }))
+    }
+
+    fn generate_key(&self) -> Result<(Box<dyn SigningKey>, PrivatePkcs8KeyDer<'static>), Error> {
+        let rng = SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+            .map_err(|_| Error::Crypto)?;
+        let pkcs8_der = PrivatePkcs8KeyDer::from(pkcs8.as_ref().to_vec());
+        let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref())
+            .map_err(|_| Error::KeyRejected)?;
+        Ok((Box::new(P256Key { key_pair, rng }), pkcs8_der))
+    }
+}
+
+struct P256Key {
+    key_pair: EcdsaKeyPair,
+    rng: SystemRandom,
+}
+
+impl SigningKey for P256Key {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Error> {
+        self.key_pair
+            .sign(&self.rng, data)
+            .map(|sig| sig.as_ref().to_vec())
+            .map_err(|_| Error::Crypto)
+    }
+
+    fn jws_algorithm(&self) -> SigningAlgorithm {
+        SigningAlgorithm::Es256
+    }
+
+    fn as_jwk(&self) -> Jwk<'_> {
+        let (x, y) = self.key_pair.public_key().as_ref()[1..].split_at(32);
+        Jwk {
+            alg: SigningAlgorithm::Es256,
+            key: JwkThumbFields::ec("P-256", x, y),
+            r#use: "sig",
+        }
+    }
+}
+
+struct Sha256;
+
+impl super::Sha256 for Sha256 {
+    fn hash(&self, data: &[u8]) -> [u8; 32] {
+        digest::digest(&digest::SHA256, data)
+            .as_ref()
+            .try_into()
+            .expect("SHA-256 output is always 32 bytes")
+    }
+}
+
+struct HmacSha256Provider;
+
+impl HmacKeyProvider for HmacSha256Provider {
+    fn load_key(&self, key_value: &[u8]) -> Box<dyn HmacKey> {
+        Box::new(HmacSha256Key(hmac::Key::new(hmac::HMAC_SHA256, key_value)))
+    }
+}
+
+struct HmacSha256Key(hmac::Key);
+
+impl HmacKey for HmacSha256Key {
+    fn algorithm(&self) -> SigningAlgorithm {
+        SigningAlgorithm::Hs256
+    }
+
+    fn sign(&self, data: &[u8]) -> Vec<u8> {
+        hmac::sign(&self.0, data).as_ref().to_vec()
+    }
+}

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -1,0 +1,99 @@
+use rustls_pki_types::PrivatePkcs8KeyDer;
+
+use ring::rand::SystemRandom;
+use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
+use ring::{digest, hmac};
+
+use super::{HmacKey, HmacKeyProvider, SigningKey, SigningKeyProvider};
+use crate::Error;
+use crate::types::{Jwk, JwkThumbFields, SigningAlgorithm};
+
+pub(crate) static PROVIDER: &super::CryptoProvider = &super::CryptoProvider {
+    signing_key: &P256SigningKeyProvider,
+    sha256: &Sha256,
+    hmac: &HmacSha256Provider,
+};
+
+struct P256SigningKeyProvider;
+
+impl SigningKeyProvider for P256SigningKeyProvider {
+    fn load_key(&self, pkcs8: PrivatePkcs8KeyDer<'static>) -> Result<Box<dyn SigningKey>, Error> {
+        let rng = SystemRandom::new();
+        let key_pair = EcdsaKeyPair::from_pkcs8(
+            &ECDSA_P256_SHA256_FIXED_SIGNING,
+            pkcs8.secret_pkcs8_der(),
+            &rng,
+        )
+        .map_err(|_| Error::KeyRejected)?;
+        Ok(Box::new(P256Key { key_pair, rng }))
+    }
+
+    fn generate_key(&self) -> Result<(Box<dyn SigningKey>, PrivatePkcs8KeyDer<'static>), Error> {
+        let rng = SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+            .map_err(|_| Error::Crypto)?;
+        let pkcs8_der = PrivatePkcs8KeyDer::from(pkcs8.as_ref().to_vec());
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+                .map_err(|_| Error::KeyRejected)?;
+        Ok((Box::new(P256Key { key_pair, rng }), pkcs8_der))
+    }
+}
+
+struct P256Key {
+    key_pair: EcdsaKeyPair,
+    rng: SystemRandom,
+}
+
+impl SigningKey for P256Key {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Error> {
+        self.key_pair
+            .sign(&self.rng, data)
+            .map(|sig| sig.as_ref().to_vec())
+            .map_err(|_| Error::Crypto)
+    }
+
+    fn jws_algorithm(&self) -> SigningAlgorithm {
+        SigningAlgorithm::Es256
+    }
+
+    fn as_jwk(&self) -> Jwk<'_> {
+        let (x, y) = self.key_pair.public_key().as_ref()[1..].split_at(32);
+        Jwk {
+            alg: SigningAlgorithm::Es256,
+            key: JwkThumbFields::ec("P-256", x, y),
+            r#use: "sig",
+        }
+    }
+}
+
+struct Sha256;
+
+impl super::Sha256 for Sha256 {
+    fn hash(&self, data: &[u8]) -> [u8; 32] {
+        digest::digest(&digest::SHA256, data)
+            .as_ref()
+            .try_into()
+            .expect("SHA-256 output is always 32 bytes")
+    }
+}
+
+struct HmacSha256Provider;
+
+impl HmacKeyProvider for HmacSha256Provider {
+    fn load_key(&self, key_value: &[u8]) -> Box<dyn HmacKey> {
+        Box::new(HmacSha256Key(hmac::Key::new(hmac::HMAC_SHA256, key_value)))
+    }
+}
+
+struct HmacSha256Key(hmac::Key);
+
+impl HmacKey for HmacSha256Key {
+    fn algorithm(&self) -> SigningAlgorithm {
+        SigningAlgorithm::Hs256
+    }
+
+    fn sign(&self, data: &[u8]) -> Vec<u8> {
+        hmac::sign(&self.0, data).as_ref().to_vec()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,22 +24,26 @@ use httpdate::HttpDate;
 #[cfg(feature = "hyper-rustls")]
 use hyper::body::Incoming;
 #[cfg(feature = "hyper-rustls")]
-use hyper_rustls::HttpsConnectorBuilder;
+use hyper_rustls::{HttpsConnectorBuilder, builderstates::WantsSchemes};
 #[cfg(feature = "hyper-rustls")]
-use hyper_rustls::builderstates::WantsSchemes;
-#[cfg(feature = "hyper-rustls")]
-use hyper_util::client::legacy::Client as HyperClient;
-#[cfg(feature = "hyper-rustls")]
-use hyper_util::client::legacy::connect::{Connect, HttpConnector};
+use hyper_util::client::legacy::{
+    Client as HyperClient,
+    connect::{Connect, HttpConnector},
+};
 #[cfg(feature = "hyper-rustls")]
 use hyper_util::rt::TokioExecutor;
 #[cfg(feature = "hyper-rustls")]
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::CryptoProvider as RustlsCryptoProvider;
 use serde::Serialize;
 
 mod account;
 pub use account::Key;
 pub use account::{Account, AccountBuilder, ExternalAccountKey};
+mod crypto;
+pub use crypto::{
+    CryptoProvider, HmacKey, HmacKeyProvider, Sha256, SigningKey, SigningKeyProvider,
+};
+pub use types::{Jwk, JwkThumbFields, SigningAlgorithm};
 mod order;
 pub use order::{
     AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
@@ -204,7 +208,7 @@ struct DefaultClient(HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, Bo
 
 #[cfg(feature = "hyper-rustls")]
 impl DefaultClient {
-    fn try_new(rustls_crypto_provider: CryptoProvider) -> Result<Self, Error> {
+    fn try_new(rustls_crypto_provider: RustlsCryptoProvider) -> Result<Self, Error> {
         Ok(Self::new(
             HttpsConnectorBuilder::new()
                 .with_provider_and_platform_verifier(rustls_crypto_provider)
@@ -214,7 +218,7 @@ impl DefaultClient {
 
     fn with_roots(
         roots: rustls::RootCertStore,
-        rustls_crypto_provider: CryptoProvider,
+        rustls_crypto_provider: RustlsCryptoProvider,
     ) -> Result<Self, Error> {
         Ok(Self::new(
             HttpsConnectorBuilder::new().with_tls_config(
@@ -378,39 +382,6 @@ pub trait BytesBody: Send {
     async fn into_bytes(&mut self) -> Result<Bytes, Box<dyn StdError + Send + Sync + 'static>>;
 }
 
-mod crypto {
-    #[cfg(feature = "aws-lc-rs")]
-    pub(crate) use aws_lc_rs as ring_like;
-    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-    pub(crate) use ring as ring_like;
-
-    pub(crate) use ring_like::digest::{Digest, SHA256, digest};
-    pub(crate) use ring_like::hmac;
-    pub(crate) use ring_like::rand::SystemRandom;
-    pub(crate) use ring_like::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
-    pub(crate) use ring_like::signature::{KeyPair, Signature};
-
-    use super::Error;
-
-    #[cfg(feature = "aws-lc-rs")]
-    pub(crate) fn p256_key_pair_from_pkcs8(
-        pkcs8: &[u8],
-        _: &SystemRandom,
-    ) -> Result<EcdsaKeyPair, Error> {
-        EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8)
-            .map_err(|_| Error::KeyRejected)
-    }
-
-    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-    pub(crate) fn p256_key_pair_from_pkcs8(
-        pkcs8: &[u8],
-        rng: &SystemRandom,
-    ) -> Result<EcdsaKeyPair, Error> {
-        EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8, rng)
-            .map_err(|_| Error::KeyRejected)
-    }
-}
-
 const CRATE_USER_AGENT: &str = concat!("instant-acme/", env!("CARGO_PKG_VERSION"));
 const JOSE_JSON: &str = "application/jose+json";
 const REPLAY_NONCE: &str = "Replay-Nonce";
@@ -421,14 +392,14 @@ const REPLAY_NONCE: &str = "Replay-Nonce";
     any(feature = "aws-lc-rs", feature = "ring")
 ))]
 mod tests {
-    use rustls::crypto::CryptoProvider;
+    use rustls::crypto::CryptoProvider as RustlsCryptoProvider;
 
     use super::*;
 
     #[tokio::test]
     async fn deserialize_old_credentials() -> Result<(), Error> {
         const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","urls":{"newNonce":"new-nonce","newAccount":"new-acct","newOrder":"new-order", "revokeCert": "revoke-cert"}}"#;
-        Account::builder(rustls_crypto_provider())?
+        Account::builder(crypto_provider(), rustls_crypto_provider())?
             .from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?)
             .await?;
         Ok(())
@@ -437,19 +408,29 @@ mod tests {
     #[tokio::test]
     async fn deserialize_new_credentials() -> Result<(), Error> {
         const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","directory":"https://acme-staging-v02.api.letsencrypt.org/directory"}"#;
-        Account::builder(rustls_crypto_provider())?
+        Account::builder(crypto_provider(), rustls_crypto_provider())?
             .from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?)
             .await?;
         Ok(())
     }
 
     #[cfg(feature = "aws-lc-rs")]
-    fn rustls_crypto_provider() -> CryptoProvider {
+    fn rustls_crypto_provider() -> RustlsCryptoProvider {
         rustls::crypto::aws_lc_rs::default_provider()
     }
 
     #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-    fn rustls_crypto_provider() -> CryptoProvider {
+    fn rustls_crypto_provider() -> RustlsCryptoProvider {
         rustls::crypto::ring::default_provider()
+    }
+
+    #[cfg(feature = "aws-lc-rs")]
+    fn crypto_provider() -> &'static CryptoProvider {
+        CryptoProvider::aws_lc_rs()
+    }
+
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    fn crypto_provider() -> &'static CryptoProvider {
+        CryptoProvider::ring()
     }
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant, SystemTime};
 use std::{fmt, slice};
 
 use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
-#[cfg(feature = "rcgen")]
+#[cfg(all(feature = "rcgen", any(feature = "aws-lc-rs", feature = "ring")))]
 use rcgen::{CertificateParams, DistinguishedName, KeyPair};
 use serde::Serialize;
 use tokio::time::sleep;
@@ -15,7 +15,7 @@ use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
     ChallengeType, DeviceAttestation, Empty, FinalizeRequest, OrderState, OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, Key, crypto, nonce_from_response, retry_after};
+use crate::{ChallengeStatus, Error, Key, nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -61,7 +61,7 @@ impl Order {
     ///
     /// After this succeeds, call [`Order::certificate()`] to retrieve the certificate chain once
     /// the order is in the appropriate state.
-    #[cfg(feature = "rcgen")]
+    #[cfg(all(feature = "rcgen", any(feature = "aws-lc-rs", feature = "ring")))]
     pub async fn finalize(&mut self) -> Result<String, Error> {
         let mut names = Vec::with_capacity(self.state.authorizations.len());
         let mut identifiers = self.identifiers();
@@ -503,7 +503,7 @@ impl ChallengeHandle<'_> {
     /// Combines a challenge's token with the thumbprint of the account's public key to compute
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
-    pub fn key_authorization(&self) -> KeyAuthorization {
+    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
         KeyAuthorization::new(self.challenge, &self.account.key)
     }
 
@@ -526,18 +526,27 @@ impl Deref for ChallengeHandle<'_> {
 /// Refer to the methods below to see which encoding to use for your challenge type.
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
-pub struct KeyAuthorization(String);
+pub struct KeyAuthorization {
+    inner: String,
+    digest: [u8; 32],
+}
 
 impl KeyAuthorization {
-    fn new(challenge: &Challenge, key: &Key) -> Self {
-        Self(format!("{}.{}", challenge.token, &key.thumb))
+    fn new(challenge: &Challenge, key: &Key) -> Result<Self, Error> {
+        let inner = format!(
+            "{}.{}",
+            challenge.token,
+            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
+        );
+        let digest = key.provider.sha256.hash(inner.as_bytes());
+        Ok(Self { inner, digest })
     }
 
     /// Get the key authorization value
     ///
     /// This can be used for HTTP-01 challenge responses.
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.inner
     }
 
     /// Get the SHA-256 digest of the key authorization
@@ -545,15 +554,15 @@ impl KeyAuthorization {
     /// This can be used for TLS-ALPN-01 challenge responses.
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> impl AsRef<[u8]> {
-        crypto::digest(&crypto::SHA256, self.0.as_bytes())
+    pub fn digest(&self) -> [u8; 32] {
+        self.digest
     }
 
     /// Get the base64-encoded SHA256 digest of the key authorization
     ///
     /// This can be used for DNS-01 challenge responses.
     pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest())
+        BASE64_URL_SAFE_NO_PAD.encode(self.digest)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -982,13 +982,25 @@ fn deserialize_static_certificate_identifier<'de, D: serde::Deserializer<'de>>(
     Ok(Some(cert_id.into_owned()))
 }
 
+/// Algorithm identifier for JWS headers
+///
+/// See the [IANA JOSE registry](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms)
+/// for the full list of registered algorithms.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
+#[non_exhaustive]
 pub(crate) enum SigningAlgorithm {
     /// ECDSA using P-256 and SHA-256
+    ///
+    /// [RFC 7518, Section 3.4](https://www.rfc-editor.org/rfc/rfc7518#section-3.4)
     Es256,
-    /// HMAC with SHA-256,
+    /// HMAC using SHA-256
+    ///
+    /// [RFC 7518, Section 3.2](https://www.rfc-editor.org/rfc/rfc7518#section-3.2)
     Hs256,
+    /// Other algorithm not represented in the enum
+    #[serde(untagged)]
+    Other(&'static str),
 }
 
 /// Attestation payload used for device-attest-01

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,62 +265,95 @@ pub(crate) struct Header<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) enum KeyOrKeyId<'a> {
     #[serde(rename = "jwk")]
-    Key(Jwk),
+    Key(Jwk<'a>),
     #[serde(rename = "kid")]
     KeyId(&'a str),
 }
 
 impl KeyOrKeyId<'_> {
-    pub(crate) fn from_key(key: &crypto::EcdsaKeyPair) -> KeyOrKeyId<'static> {
+    pub(crate) fn from_key(key: &crypto::EcdsaKeyPair) -> KeyOrKeyId<'_> {
         KeyOrKeyId::Key(Jwk::new(key))
     }
 }
 
+/// A JSON Web Key (JWK) as used in JWS headers
+///
+/// See [RFC 7517](https://www.rfc-editor.org/rfc/rfc7517) for more information.
 #[derive(Debug, Serialize)]
-pub(crate) struct Jwk {
+pub(crate) struct Jwk<'a> {
+    /// The algorithm intended for use with this key
     alg: SigningAlgorithm,
-    crv: &'static str,
-    kty: &'static str,
+    /// Key-type-specific parameters
+    #[serde(flatten)]
+    key: JwkThumbFields<'a>,
+    /// The intended use (`"sig"` for signing)
     r#use: &'static str,
-    x: String,
-    y: String,
 }
 
-impl Jwk {
-    pub(crate) fn new(key: &crypto::EcdsaKeyPair) -> Self {
+impl<'a> Jwk<'a> {
+    pub(crate) fn new(key: &'a crypto::EcdsaKeyPair) -> Self {
         let (x, y) = key.public_key().as_ref()[1..].split_at(32);
-        Self {
+        Jwk {
             alg: SigningAlgorithm::Es256,
-            crv: "P-256",
-            kty: "EC",
+            key: JwkThumbFields::ec("P-256", x, y),
             r#use: "sig",
-            x: BASE64_URL_SAFE_NO_PAD.encode(x),
-            y: BASE64_URL_SAFE_NO_PAD.encode(y),
         }
     }
 
-    pub(crate) fn thumb_sha256(
-        key: &crypto::EcdsaKeyPair,
-    ) -> Result<crypto::Digest, serde_json::Error> {
-        let jwk = Self::new(key);
+    /// Compute the [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) JWK thumbprint.
+    ///
+    /// Serializes only the required key-type-specific members in lexicographic order,
+    /// then hashes with SHA-256.
+    pub(crate) fn thumb_sha256(&'a self) -> Result<crypto::Digest, serde_json::Error> {
         Ok(crypto::digest(
             &crypto::SHA256,
-            &serde_json::to_vec(&JwkThumb {
-                crv: jwk.crv,
-                kty: jwk.kty,
-                x: &jwk.x,
-                y: &jwk.y,
-            })?,
+            &serde_json::to_vec(&self.key)?,
         ))
     }
 }
 
+/// Key-type-specific JWK parameters
+///
+/// Each variant's fields are declared in lexicographic order for correct
+/// [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) thumbprint computation.
 #[derive(Debug, Serialize)]
-struct JwkThumb<'a> {
-    crv: &'a str,
-    kty: &'a str,
-    x: &'a str,
-    y: &'a str,
+#[serde(untagged)]
+pub(crate) enum JwkThumbFields<'a> {
+    /// Elliptic Curve key (P-256, P-384, etc.)
+    ///
+    /// Construct via [`JwkThumbFields::ec()`].
+    Ec {
+        /// The curve name (e.g., `"P-256"`)
+        crv: &'static str,
+        /// Key type (always `"EC"`, set automatically by [`JwkThumbFields::ec`])
+        kty: &'static str,
+        /// The x coordinate (serialized as base64url)
+        #[serde(serialize_with = "base64url::serialize")]
+        x: &'a [u8],
+        /// The y coordinate (serialized as base64url)
+        #[serde(serialize_with = "base64url::serialize")]
+        y: &'a [u8],
+    },
+}
+
+impl<'a> JwkThumbFields<'a> {
+    pub(crate) fn ec(crv: &'static str, x: &'a [u8], y: &'a [u8]) -> Self {
+        Self::Ec {
+            crv,
+            kty: "EC",
+            x,
+            y,
+        }
+    }
+}
+
+mod base64url {
+    use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
+    use serde::Serializer;
+
+    pub(crate) fn serialize<S: Serializer>(data: &&[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&BASE64_URL_SAFE_NO_PAD.encode(*data))
+    }
 }
 
 /// An ACME challenge as described in RFC 8555 (section 7.1.5)

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,8 +18,7 @@ use x509_parser::extensions::ParsedExtension;
 #[cfg(feature = "x509-parser")]
 use x509_parser::parse_x509_certificate;
 
-use crate::BytesResponse;
-use crate::crypto::{self, KeyPair};
+use crate::{BytesResponse, Sha256};
 
 /// Error type for instant-acme
 #[derive(Debug, Error)]
@@ -66,7 +65,7 @@ pub enum Error {
 }
 
 impl Error {
-    #[cfg(feature = "rcgen")]
+    #[cfg(all(feature = "rcgen", any(feature = "aws-lc-rs", feature = "ring")))]
     pub(crate) fn from_rcgen(err: rcgen::Error) -> Self {
         Self::Other(Box::new(err))
     }
@@ -270,45 +269,30 @@ pub(crate) enum KeyOrKeyId<'a> {
     KeyId(&'a str),
 }
 
-impl KeyOrKeyId<'_> {
-    pub(crate) fn from_key(key: &crypto::EcdsaKeyPair) -> KeyOrKeyId<'_> {
-        KeyOrKeyId::Key(Jwk::new(key))
-    }
-}
-
 /// A JSON Web Key (JWK) as used in JWS headers
 ///
 /// See [RFC 7517](https://www.rfc-editor.org/rfc/rfc7517) for more information.
 #[derive(Debug, Serialize)]
-pub(crate) struct Jwk<'a> {
+pub struct Jwk<'a> {
     /// The algorithm intended for use with this key
-    alg: SigningAlgorithm,
+    pub alg: SigningAlgorithm,
     /// Key-type-specific parameters
     #[serde(flatten)]
-    key: JwkThumbFields<'a>,
+    pub key: JwkThumbFields<'a>,
     /// The intended use (`"sig"` for signing)
-    r#use: &'static str,
+    pub r#use: &'static str,
 }
 
 impl<'a> Jwk<'a> {
-    pub(crate) fn new(key: &'a crypto::EcdsaKeyPair) -> Self {
-        let (x, y) = key.public_key().as_ref()[1..].split_at(32);
-        Jwk {
-            alg: SigningAlgorithm::Es256,
-            key: JwkThumbFields::ec("P-256", x, y),
-            r#use: "sig",
-        }
-    }
-
     /// Compute the [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) JWK thumbprint.
     ///
     /// Serializes only the required key-type-specific members in lexicographic order,
     /// then hashes with SHA-256.
-    pub(crate) fn thumb_sha256(&'a self) -> Result<crypto::Digest, serde_json::Error> {
-        Ok(crypto::digest(
-            &crypto::SHA256,
-            &serde_json::to_vec(&self.key)?,
-        ))
+    pub(crate) fn thumb_sha256(
+        &'a self,
+        sha256: &dyn Sha256,
+    ) -> Result<[u8; 32], serde_json::Error> {
+        Ok(sha256.hash(&serde_json::to_vec(&self.key)?))
     }
 }
 
@@ -318,10 +302,12 @@ impl<'a> Jwk<'a> {
 /// [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) thumbprint computation.
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
-pub(crate) enum JwkThumbFields<'a> {
+#[non_exhaustive]
+pub enum JwkThumbFields<'a> {
     /// Elliptic Curve key (P-256, P-384, etc.)
     ///
     /// Construct via [`JwkThumbFields::ec()`].
+    #[non_exhaustive]
     Ec {
         /// The curve name (e.g., `"P-256"`)
         crv: &'static str,
@@ -337,7 +323,8 @@ pub(crate) enum JwkThumbFields<'a> {
 }
 
 impl<'a> JwkThumbFields<'a> {
-    pub(crate) fn ec(crv: &'static str, x: &'a [u8], y: &'a [u8]) -> Self {
+    /// Create an Elliptic Curve JWK with the given curve name and coordinates
+    pub fn ec(crv: &'static str, x: &'a [u8], y: &'a [u8]) -> Self {
         Self::Ec {
             crv,
             kty: "EC",
@@ -632,7 +619,7 @@ impl JoseJson {
         Ok(Self {
             protected,
             payload,
-            signature: BASE64_URL_SAFE_NO_PAD.encode(signature.as_ref()),
+            signature: BASE64_URL_SAFE_NO_PAD.encode(signature),
         })
     }
 }
@@ -989,7 +976,7 @@ fn deserialize_static_certificate_identifier<'de, D: serde::Deserializer<'de>>(
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
 #[non_exhaustive]
-pub(crate) enum SigningAlgorithm {
+pub enum SigningAlgorithm {
     /// ECDSA using P-256 and SHA-256
     ///
     /// [RFC 7518, Section 3.4](https://www.rfc-editor.org/rfc/rfc7518#section-3.4)
@@ -1016,7 +1003,7 @@ pub(crate) struct Empty {}
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "x509-parser")]
+    #[cfg(all(feature = "x509-parser", any(feature = "aws-lc-rs", feature = "ring")))]
     use rcgen::{
         BasicConstraints, CertificateParams, DistinguishedName, IsCa, Issuer, KeyIdMethod, KeyPair,
         SerialNumber,
@@ -1234,7 +1221,7 @@ mod tests {
         assert_eq!(serialized, r#""aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE""#);
     }
 
-    #[cfg(feature = "x509-parser")]
+    #[cfg(all(feature = "x509-parser", any(feature = "aws-lc-rs", feature = "ring")))]
     #[test]
     fn encoded_certificate_identifier_from_cert() {
         // Generate a CA key_pair and self-signed cert with a specific subject key identifier.

--- a/src/types.rs
+++ b/src/types.rs
@@ -320,6 +320,33 @@ pub enum JwkThumbFields<'a> {
         #[serde(serialize_with = "base64url::serialize")]
         y: &'a [u8],
     },
+    /// Octet Key Pair (Ed25519, Ed448, X25519, etc.)
+    ///
+    /// Construct via [`JwkThumbFields::okp()`].
+    #[non_exhaustive]
+    Okp {
+        /// The curve name (e.g., `"Ed25519"`)
+        crv: &'static str,
+        /// Key type (always `"OKP"`, set automatically by [`JwkThumbFields::okp`])
+        kty: &'static str,
+        /// The public key (serialized as base64url)
+        #[serde(serialize_with = "base64url::serialize")]
+        x: &'a [u8],
+    },
+    /// RSA key
+    ///
+    /// Construct via [`JwkThumbFields::rsa()`].
+    #[non_exhaustive]
+    Rsa {
+        /// The public exponent (serialized as base64url)
+        #[serde(serialize_with = "base64url::serialize")]
+        e: &'a [u8],
+        /// Key type (always `"RSA"`, set automatically by [`JwkThumbFields::rsa`])
+        kty: &'static str,
+        /// The modulus (serialized as base64url)
+        #[serde(serialize_with = "base64url::serialize")]
+        n: &'a [u8],
+    },
 }
 
 impl<'a> JwkThumbFields<'a> {
@@ -331,6 +358,16 @@ impl<'a> JwkThumbFields<'a> {
             x,
             y,
         }
+    }
+
+    /// Create an Octet Key Pair JWK with the given curve name and public key
+    pub fn okp(crv: &'static str, x: &'a [u8]) -> Self {
+        Self::Okp { crv, kty: "OKP", x }
+    }
+
+    /// Create an RSA JWK with the given public exponent and modulus
+    pub fn rsa(e: &'a [u8], n: &'a [u8]) -> Self {
+        Self::Rsa { e, kty: "RSA", n }
     }
 }
 
@@ -977,14 +1014,27 @@ fn deserialize_static_certificate_identifier<'de, D: serde::Deserializer<'de>>(
 #[serde(rename_all = "UPPERCASE")]
 #[non_exhaustive]
 pub enum SigningAlgorithm {
+    /// EdDSA using the Ed25519 parameter set in Section 5.1 of [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032)
+    ///
+    /// [RFC 9864, Section 2.2](https://www.rfc-editor.org/rfc/rfc9864#section-2.2)
+    #[serde(rename = "Ed25519")]
+    Ed25519,
     /// ECDSA using P-256 and SHA-256
     ///
     /// [RFC 7518, Section 3.4](https://www.rfc-editor.org/rfc/rfc7518#section-3.4)
     Es256,
+    /// ECDSA using P-384 and SHA-384
+    ///
+    /// [RFC 7518, Section 3.4](https://www.rfc-editor.org/rfc/rfc7518#section-3.4)
+    Es384,
     /// HMAC using SHA-256
     ///
     /// [RFC 7518, Section 3.2](https://www.rfc-editor.org/rfc/rfc7518#section-3.2)
     Hs256,
+    /// RSASSA-PKCS1-v1_5 using SHA-256
+    ///
+    /// [RFC 7518, Section 3.3](https://www.rfc-editor.org/rfc/rfc7518#section-3.3)
+    Rs256,
     /// Other algorithm not represented in the enum
     #[serde(untagged)]
     Other(&'static str),

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -456,7 +456,7 @@ async fn account_create_from_key() -> Result<(), Box<dyn StdError>> {
     let directory_url = format!("https://{}/dir", &env.config.pebble.listen_address);
 
     // Generate a new key
-    let (key, key_pkcs8) = Key::generate_pkcs8()?;
+    let (key, key_pkcs8) = Key::generate()?;
 
     // Create a new account with the generated key
     let (account1, credentials1) = Account::builder_with_http(Box::new(env.client.clone()))

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -1,3 +1,4 @@
+#![cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 //! Note: tests in the file are ignored by default because they requires `pebble` and
 //! `pebble-challtestsrv` binaries.
 //!
@@ -24,15 +25,15 @@ use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use instant_acme::{
-    Account, AuthorizationStatus, BodyWrapper, ChallengeHandle, ChallengeType, Error,
-    ExternalAccountKey, Identifier, Key, KeyAuthorization, NewAccount, NewOrder, Order,
+    Account, AuthorizationStatus, BodyWrapper, ChallengeHandle, ChallengeType, CryptoProvider,
+    Error, ExternalAccountKey, Identifier, Key, KeyAuthorization, NewAccount, NewOrder, Order,
     OrderStatus, RetryPolicy,
 };
 #[cfg(all(feature = "time", feature = "x509-parser"))]
 use instant_acme::{CertificateIdentifier, RevocationRequest};
 use rustls::RootCertStore;
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, verify_server_name};
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::CryptoProvider as RustlsCryptoProvider;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::server::ParsedCertificate;
@@ -161,7 +162,7 @@ async fn eab_required() -> Result<(), Box<dyn StdError>> {
     config.pebble.external_account_mac_keys = mac_keys;
     config.eab_key = Some(ExternalAccountKey::new(
         eab_id.to_string(),
-        raw_eab_hmac_key.as_ref(),
+        test_provider().hmac.load_key(raw_eab_hmac_key.as_ref()),
     ));
     Environment::new(config).await.map(|_| ())
 }
@@ -362,7 +363,7 @@ async fn update_key() -> Result<(), Box<dyn StdError>> {
     );
 
     // Change the Pebble environment to use the new ACME account key.
-    env.account = Account::builder_with_http(Box::new(env.client.clone()))
+    env.account = Account::builder_with_http(Box::new(env.client.clone()), test_provider())
         .from_credentials(new_credentials)
         .await?;
 
@@ -385,17 +386,19 @@ async fn account_from_key() -> Result<(), Box<dyn StdError>> {
     let env = Environment::new(EnvironmentConfig::default()).await?;
     let directory_url = format!("https://{}/dir", &env.config.pebble.listen_address);
 
-    let (account1, credentials) = Account::builder_with_http(Box::new(env.client.clone()))
-        .create(
-            &NewAccount {
-                contact: &[],
-                terms_of_service_agreed: true,
-                only_return_existing: false,
-            },
-            directory_url.clone(),
-            None,
-        )
-        .await?;
+    let provider = test_provider();
+    let (account1, credentials) =
+        Account::builder_with_http(Box::new(env.client.clone()), provider)
+            .create(
+                &NewAccount {
+                    contact: &[],
+                    terms_of_service_agreed: true,
+                    only_return_existing: false,
+                },
+                directory_url.clone(),
+                None,
+            )
+            .await?;
 
     #[derive(Deserialize)]
     struct JsonKey<'a> {
@@ -405,14 +408,15 @@ async fn account_from_key() -> Result<(), Box<dyn StdError>> {
     let json1 = serde_json::to_string(&credentials)?;
     let json_key = serde_json::from_str::<JsonKey<'_>>(&json1)?;
     let key_der = BASE64_URL_SAFE_NO_PAD.decode(json_key.key_pkcs8)?;
-    let key = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()))?;
+    let key = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()), provider)?;
 
-    let (account2, credentials2) = Account::builder_with_http(Box::new(env.client.clone()))
-        .from_key(
-            (key, PrivateKeyDer::try_from(key_der.clone())?),
-            directory_url,
-        )
-        .await?;
+    let (account2, credentials2) =
+        Account::builder_with_http(Box::new(env.client.clone()), provider)
+            .from_key(
+                (key, PrivateKeyDer::try_from(key_der.clone())?),
+                directory_url,
+            )
+            .await?;
 
     assert_eq!(account1.id(), account2.id());
     assert_eq!(
@@ -425,8 +429,8 @@ async fn account_from_key() -> Result<(), Box<dyn StdError>> {
     let env = Environment::new(EnvironmentConfig::default()).await?;
     let directory_url = format!("https://{}/dir", &env.config.pebble.listen_address);
 
-    let key = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()))?;
-    let result = Account::builder_with_http(Box::new(env.client.clone()))
+    let key = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()), provider)?;
+    let result = Account::builder_with_http(Box::new(env.client.clone()), provider)
         .from_key((key, PrivateKeyDer::try_from(key_der)?), directory_url)
         .await;
 
@@ -456,18 +460,21 @@ async fn account_create_from_key() -> Result<(), Box<dyn StdError>> {
     let directory_url = format!("https://{}/dir", &env.config.pebble.listen_address);
 
     // Generate a new key
-    let (key, key_pkcs8) = Key::generate()?;
+    let provider = test_provider();
+    let (key, key_pkcs8) = Key::generate(provider)?;
 
     // Create a new account with the generated key
-    let (account1, credentials1) = Account::builder_with_http(Box::new(env.client.clone()))
-        .create_from_key(
-            (
-                key,
-                PrivateKeyDer::try_from(key_pkcs8.secret_pkcs8_der().to_vec())?,
-            ),
-            directory_url.clone(),
-        )
-        .await?;
+    let (account1, credentials1) =
+        Account::builder_with_http(Box::new(env.client.clone()), provider)
+            .create_from_key(
+                (
+                    key,
+                    PrivateKeyDer::try_from(key_pkcs8.secret_pkcs8_der().to_vec())
+                        .expect("PKCS#8 key should be valid"),
+                ),
+                directory_url.clone(),
+            )
+            .await?;
 
     // Extract the key to verify it matches what we provided
     #[derive(Deserialize)]
@@ -483,10 +490,11 @@ async fn account_create_from_key() -> Result<(), Box<dyn StdError>> {
     assert_eq!(key_der, key_pkcs8.secret_pkcs8_der());
 
     // Now try to load the account using from_key to verify it was created
-    let key2 = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()))?;
-    let (account2, credentials2) = Account::builder_with_http(Box::new(env.client.clone()))
-        .from_key((key2, PrivateKeyDer::try_from(key_der)?), directory_url)
-        .await?;
+    let key2 = Key::from_pkcs8_der(PrivatePkcs8KeyDer::from(key_der.clone()), provider)?;
+    let (account2, credentials2) =
+        Account::builder_with_http(Box::new(env.client.clone()), provider)
+            .from_key((key2, PrivateKeyDer::try_from(key_der)?), directory_url)
+            .await?;
 
     // Both should be the same account
     assert_eq!(account1.id(), account2.id());
@@ -602,7 +610,7 @@ impl Environment {
 
         // Create a new `Account` with the ACME server.
         debug!("creating test account");
-        let (account, _) = Account::builder_with_http(Box::new(client.clone()))
+        let (account, _) = Account::builder_with_http(Box::new(client.clone()), test_provider())
             .create(
                 &NewAccount {
                     contact: &[],
@@ -648,7 +656,7 @@ impl Environment {
                 .challenge(A::TYPE)
                 .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
 
-            let key_authz = challenge.key_authorization();
+            let key_authz = challenge.key_authorization()?;
             self.request_challenge::<A>(&challenge, &key_authz).await?;
 
             debug!(challenge_url = challenge.url, "marking challenge ready");
@@ -669,7 +677,7 @@ impl Environment {
         let ee_cert = ParsedCertificate::try_from(ee_cert_der).unwrap();
 
         // Use the default crypto provider to verify the certificate chain to the Pebble CA root.
-        let crypto_provider = CryptoProvider::get_default().unwrap();
+        let crypto_provider = RustlsCryptoProvider::get_default().unwrap();
         verify_server_cert_signed_by_trust_anchor(
             &ee_cert,
             &self.issuer_roots().await?,
@@ -1017,6 +1025,13 @@ impl Drop for Subprocess {
             child.wait().expect("failed to wait for killed subprocess");
         }
     }
+}
+
+fn test_provider() -> &'static CryptoProvider {
+    #[cfg(feature = "aws-lc-rs")]
+    return CryptoProvider::aws_lc_rs();
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    return CryptoProvider::ring();
 }
 
 static NEXT_PORT: AtomicU16 = AtomicU16::new(5555);


### PR DESCRIPTION
Implements base for #267, allowing users to bring their own crypto.

Marked as draft for now, will un-draft once I've implemented (and tested) backends with other crypto libraries, like openssl and rustcrypto to validate this approach is viable.